### PR TITLE
fix(thread): #CO-1003 add indication when last message is delete

### DIFF
--- a/src/main/resources/public/template/home.html
+++ b/src/main/resources/public/template/home.html
@@ -93,12 +93,15 @@
                         <em>[[formatDateFromNow(subject.lastMessage.created.$date)]]</em>
                     </div>
                     <div class="fixed-small centered-text">
-                        <img ng-src="/userbook/avatar/[[subject.lastMessage.owner.userId]]?thumbnail=48x48">
+                        <img ng-if="!!subject.lastMessage" ng-src="/userbook/avatar/[[subject.lastMessage.owner.userId]]?thumbnail=48x48">
                     </div>
-                    <div class="bubble-container ellipsis" ng-click="openSubject(subject)">
+                    <div ng-if="!!subject.lastMessage" class="bubble-container ellipsis" ng-click="openSubject(subject)">
                         <div class="bubble-small">
                             [[ extractText(subject.lastMessage) ]]
                         </div>
+                    </div>
+                    <div ng-if="!subject.lastMessage" class="ellipsis" ng-click="openSubject(subject)">
+                        <i18n>forum.message.deleted</i18n>
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
## Describe your changes
Add indication when last message is delete

## Checklist tests
Create a thread. Delete the message. In the listing we can see "Message deleted" and the user image is not show

## Issue ticket number and link
[CO-1003](https://jira.support-ent.fr/browse/CO-1003)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

